### PR TITLE
fix(multipass): give same architecture value for windows and linux

### DIFF
--- a/colcon_in_container/providers/config/cloud-init.yaml
+++ b/colcon_in_container/providers/config/cloud-init.yaml
@@ -6,11 +6,7 @@
 apt:
   sources:
     ros2:
-{% if v1.distro_release == "noble" %}
-      source: "deb [arch={{ archmap[v1.machine] }}] http://packages.ros.org/ros2-testing/ubuntu {{ v1.distro_release }} main"
-{% else %}
       source: "deb [arch={{ archmap[v1.machine] }}] http://packages.ros.org/ros2/ubuntu {{ v1.distro_release }} main"
-{% endif %}
       keyid: C1CF 6E31 E6BA DE88 68B1 72B4 F42E D6FB AB17 C654
 package_update: true
 package_upgrade: true

--- a/colcon_in_container/providers/multipass.py
+++ b/colcon_in_container/providers/multipass.py
@@ -14,7 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
-from platform import processor
+from platform import machine
 import shutil
 import subprocess
 from typing import List
@@ -71,8 +71,16 @@ class MultipassClient(Provider):
             config = f.read()
 
         template = jinja2.Environment().from_string(source=config)
+        host_architecture = machine()
+        # support for windows 10 and 11 returning all kinds of values
+        # bugs.python.org/issue7146
+        if host_architecture in ['AMD64', 'amd64', 'x64']:
+            host_architecture = 'x86_64'
+        elif host_architecture in ['ARM64', 'arm64']:
+            host_architecture = 'aarch64'
+
         cloud_init_content = template.render(
-            {'v1': {'machine': processor(),
+            {'v1': {'machine': host_architecture,
                     'distro_release': self.ubuntu_distro}}
         )
 


### PR DESCRIPTION
Fixes: https://github.com/canonical/colcon-in-container/issues/19


Useful info: bugs.python.org/issue7146