### PR TITLE
fix(iron): iron is EoL

### DIFF
--- a/.github/workflows/colcon_in_container.yaml
+++ b/.github/workflows/colcon_in_container.yaml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, [self-hosted, linux, X64, jammy, xlarge]]
-        ros_version: [jazzy, humble, iron, rolling]
+        ros_version: [jazzy, humble, rolling]
         provider: [lxd, multipass]
         exclude:
           - os: ubuntu-20.04

--- a/colcon_in_container/providers/_helper.py
+++ b/colcon_in_container/providers/_helper.py
@@ -17,7 +17,6 @@ from platform import processor
 
 
 _ros2_ubuntu_distro = {'rolling': 'noble',
-                       'iron': 'jammy',
                        'humble': 'jammy',
                        'jazzy': 'noble'}
 

--- a/colcon_in_container/verb/_parser.py
+++ b/colcon_in_container/verb/_parser.py
@@ -18,7 +18,7 @@ from os import getenv
 from colcon_in_container.logging import logger
 
 
-_ros_distro_choices = ['rolling', 'iron', 'humble', 'jazzy']
+_ros_distro_choices = ['rolling', 'humble', 'jazzy']
 
 
 def add_ros_distro_argument(parser):


### PR DESCRIPTION
Close https://github.com/canonical/colcon-in-container/issues/31

Iron is now EoL and not a LTS distro.

Removing it from the tool.