### PR TITLE
Feat/enable ubuntu pro and eol

### DIFF
--- a/.github/workflows/colcon_in_container.yaml
+++ b/.github/workflows/colcon_in_container.yaml
@@ -34,6 +34,10 @@ jobs:
       - name: Install LXD
         if: ${{ matrix.provider == 'lxd' }}
         uses: canonical/setup-lxd@v0.1.0
+      - name: Install Multipass
+        run: |
+          sudo snap install multipass
+        if: "${{ matrix.provider == 'multipass' }}"
       - name: Install dependencies
         run: |
           sudo apt update
@@ -42,10 +46,6 @@ jobs:
           python3 -m pip install --upgrade pip
           pip install setuptools
           pip install colcon-common-extensions
-
-          if [ ${{ matrix.provider }} == 'multipass' ]; then
-            sudo snap install multipass
-          fi
       - name: Install the extension
         run: |
           pip install .
@@ -105,6 +105,10 @@ jobs:
       - name: Install LXD
         if: ${{ matrix.provider == 'lxd' }}
         uses: canonical/setup-lxd@v0.1.0
+      - name: Install Multipass
+        run: |
+          sudo snap install multipass
+        if: "${{ matrix.provider == 'multipass' }}"
       - name: Install dependencies
         run: |
           sudo apt update
@@ -113,10 +117,6 @@ jobs:
           python3 -m pip install --upgrade pip
           pip install setuptools
           pip install colcon-common-extensions
-
-          if [ ${{ matrix.provider }} == 'multipass' ]; then
-            sudo snap install multipass
-          fi
       - name: Install the extension
         run: |
           pip install .

--- a/.github/workflows/colcon_in_container.yaml
+++ b/.github/workflows/colcon_in_container.yaml
@@ -129,7 +129,7 @@ jobs:
       - name: Colcon build in container
         run: |
           cd ros_ws
-          # pendulum_msgs pendulum_control depends on tlsf packages not present in the ROS ESM
+          # Note that pendulum_control depends on the tlsf_cpp package not present in ROS ESM nor in the workspace sources
           colcon --log-level=debug build-in-container --pro ${{ secrets.PRO_TOKEN }} --auto-deps-management --packages-select pendulum_msgs pendulum_control --provider ${{ matrix.provider}} --ros-distro ${{ matrix.ros_version }}
       - name: Colcon build in container verify files
         run: |

--- a/.github/workflows/colcon_in_container.yaml
+++ b/.github/workflows/colcon_in_container.yaml
@@ -85,3 +85,83 @@ jobs:
           ls release_in_container/COLCON_IGNORE
           ls release_in_container/demo_nodes_cpp/debian
 
+  eol_distro_in_container_integration_test:
+    name: "EoL distro Integration Test"
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04, [self-hosted, linux, X64, jammy, xlarge]]
+        ros_version: [foxy]
+        provider: [lxd, multipass]
+        exclude:
+          - os: ubuntu-24.04
+            provider: multipass
+          - {os: [self-hosted, linux, X64, jammy, xlarge], provider: lxd}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+      - uses: actions/setup-python@v5
+      - name: Install LXD
+        if: ${{ matrix.provider == 'lxd' }}
+        uses: canonical/setup-lxd@v0.1.0
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt upgrade -y
+          sudo rm /usr/lib/python3.*/EXTERNALLY-MANAGED || true
+          python3 -m pip install --upgrade pip
+          pip install setuptools
+          pip install colcon-common-extensions
+
+          if [ ${{ matrix.provider }} == 'multipass' ]; then
+            sudo snap install multipass
+          fi
+      - name: Install the extension
+        run: |
+          pip install .
+      - name: Checkout example to build
+        uses: actions/checkout@v3
+        with:
+          path: ros_ws/src/ros2demo
+          repository: ros2/demos
+          ref: ${{ matrix.ros_version }}
+      - name: Colcon build in container
+        run: |
+          cd ros_ws
+          # pendulum_msgs pendulum_control depends on tlsf packages not present in the ROS ESM
+          colcon --log-level=debug build-in-container --pro ${{ secrets.PRO_TOKEN }} --auto-deps-management --packages-select pendulum_msgs pendulum_control --provider ${{ matrix.provider}} --ros-distro ${{ matrix.ros_version }}
+      - name: Colcon build in container verify files
+        run: |
+          cd ros_ws
+
+          # dependencies underlay workspace
+          grep ${{ matrix.ros_version }} install_in_container_underlay/setup.sh
+          ls build_in_container_underlay/tlsf_cpp/Makefile
+          ls install_in_container_underlay/tlsf_cpp/bin/tlsf_allocator_example
+
+          # package workspace
+          grep ${{ matrix.ros_version }} install_in_container/setup.sh
+          ls build_in_container/pendulum_control/Makefile
+          ls install_in_container/pendulum_control/bin/pendulum_demo
+      - name: Colcon test in container
+        run: |
+          cd ros_ws
+          colcon --log-level=debug test-in-container --pro ${{ secrets.PRO_TOKEN }} --auto-deps-management --packages-select pendulum_msgs pendulum_control --provider ${{ matrix.provider}} --ros-distro ${{ matrix.ros_version }} --colcon-test-args "--return-code-on-test-failure"
+      - name: Colcon test in container verify files
+        run: |
+          cd ros_ws
+          grep "Hostname=\"colcon-in-container\"" test_results_in_container/pendulum_control/Testing/*/Test.xml
+      ## commented due to https://github.com/canonical/colcon-in-container/issues/25
+      # - name: Colcon release in container
+      #   run: |
+      #     cd ros_ws
+      #     colcon --log-level=debug release-in-container --pro ${{ secrets.PRO_TOKEN }} --auto-deps-management --provider ${{ matrix.provider}} --ros-distro ${{ matrix.ros_version }} --packages-select pendulum_control --bloom-generator="rosdebian"
+      # - name: Colcon release in container verify files
+      #   run: |
+      #     cd ros_ws
+      #     ls release_in_container/demo_nodes_cpp/ros-${{ matrix.ros_version }}-demo-nodes-cpp_*.deb
+      #     ls release_in_container/demo_nodes_cpp/ros-${{ matrix.ros_version }}-demo-nodes-cpp-dbgsym_*.ddeb
+      #     ls release_in_container/COLCON_IGNORE
+      #     ls release_in_container/demo_nodes_cpp/debian
+

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ For ROS distribution beyond EoL, `colcon in-container` integrates [Ubuntu Pro](h
 (https://ubuntu.com/robotics/ros-esm) so you can benefit from security updates for up to 12 years.
 Get your free Ubuntu Pro token at [ubuntu.com/pro/dashboard](https://ubuntu.com/pro/dashboard) and give it a shot.
 
-While EoL distro are limited in `colcon in-container` to use `pro`, you can get a free token on the
+Note that `colcon in-container` solely supports EoL distros in conjunction with `pro`.
 [Ubuntu Pro dashboard](https://ubuntu.com/pro/dashboard).
 
 ### `--pro`

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Usage help:
 $ colcon build-in-container --help
 
 usage: colcon build-in-container [-h] [--ros-distro ROS_DISTRO] [--colcon-build-args *] [--debug] [--shell-after]
-[--provider {lxd,multipass}] [--pro PRO] [--auto-deps-management]
+[--provider {lxd,multipass}] [--pro PRO_TOKEN] [--auto-deps-management]
 
 Call a colcon build command inside a fresh container.
 
@@ -135,7 +135,7 @@ options:
   --debug               Shell into the environment in case the build fails.
   --shell-after         Shell into the environment at the end of the build or if there is an error. This flag includes "--debug".
   --provider {lxd, multipass}      Environment provider.
-  --pro PRO             Ubuntu Pro token to enable inside the instance.
+  --pro PRO_TOKEN       Ubuntu Pro token to enable ROS ESM inside the instance.
   --auto-deps-management
                         Automatically manages missing dependencies.This will retrieve, install and source the ROS
                         dependencies of the workspace not available in ROS ESM
@@ -161,7 +161,7 @@ Usage help:
 $ colcon test-in-container --help
 
 usage: colcon test-in-container [-h] [--ros-distro ROS_DISTRO] [--colcon-test-args *] [--debug] [--shell-after]
-[--provider {lxd,multipass}] [--pro PRO] [--auto-deps-management]
+[--provider {lxd,multipass}] [--pro PRO_TOKEN] [--auto-deps-management]
 
 Call a colcon test command inside a fresh container.
 
@@ -175,7 +175,7 @@ options:
   --shell-after         Shell into the environment at the end of the build or if there is an
                         error. This flag includes "--debug".
   --provider {lxd, multipass}      Environment provider.
-  --pro PRO             Ubuntu Pro token to enable inside the instance.
+  --pro PRO_TOKEN       Ubuntu Pro token to enable ROS ESM inside the instance.
   --auto-deps-management
                         Automatically manages missing dependencies.This will retrieve, install and source the ROS
                         dependencies of the workspace not available in ROS ESM
@@ -201,7 +201,7 @@ Usage help:
 $ colcon release-in-container --help
 
 usage: colcon release-in-container [-h] [--ros-distro ROS_DISTRO] [--bloom-generator {debian,rosdebian}] [--debug]
-[--shell-after] [--provider {lxd,multipass}] [--pro PRO] [--auto-deps-management]
+[--shell-after] [--provider {lxd,multipass}] [--pro PRO_TOKEN] [--auto-deps-management]
 
 Generate Debian package inside a fresh container using bloom and fakeroot.
 
@@ -215,7 +215,7 @@ options:
   --debug               Shell into the environment in case the build fails.
   --shell-after         Shell into the environment at the end of the build or if there is an error. This flag includes "--debug".
   --provider {lxd, multipass}      Environment provider.
-  --pro PRO             Ubuntu Pro token to enable inside the instance.
+  --pro PRO_TOKEN       Ubuntu Pro token to enable ROS ESM inside the instance.
   --auto-deps-management
                         Automatically manages missing dependencies.This will retrieve, install and source the ROS
                         dependencies of the workspace not available in ROS ESM

--- a/README.md
+++ b/README.md
@@ -231,24 +231,22 @@ For ROS distribution beyond EoL, `colcon in-container` integrates [Ubuntu Pro](h
 Get your free Ubuntu Pro token at [ubuntu.com/pro/dashboard](https://ubuntu.com/pro/dashboard) and give it a shot.
 
 Note that `colcon in-container` solely supports EoL distros in conjunction with `pro`.
-[Ubuntu Pro dashboard](https://ubuntu.com/pro/dashboard).
 
 ### `--pro`
 
-This flag will let you pass the mandatory Ubuntu Pro token and automatically enable
+This flag will let you pass the Ubuntu Pro token to automatically enable
 [Ubuntu Pro](https://ubuntu.com/pro) and [ROS ESM](https://ubuntu.com/robotics/ros-esm).
 
 ### `--auto-deps-management`
 
-This flag will enable the automatic dependencies management.
+This flag enables the automatic dependencies management.
 
-ROS ESM covers up to the meta-package `ros-$DISTRO-ros-base`. Some ROS packages originally present in the ROS 
-repository might not be present in your workspace.
+ROS ESM covers up to the meta-package `ros-$DISTRO-ros-base`.
+However your package may have ROS dependencies that aren't covered by ROS ESM.
 With the help of the tool [`ros-esm-dependencies-diff-generator`](https://snapcraft.io/ros-esm-dependencies-diff-generator),
-the `--auto-deps-management` flag will take care of finding the dependencies, and installing them within the 
+the `--auto-deps-management` flag takes care of fetching those dependencies sources, and compiles them against ROS ESM within the
 isolated environment.
-
-At the end, the `build/` and `install/` directories of the `ws_underlay` containing the dependencies are downloaded on
+The intermediate dependencies are compiled in a separate underlay colcon workspace which is separately downloaded on
 the host under: `build_in_container_underlay` and `install_in_container_underlay/`
 
 ## Use cases

--- a/README.md
+++ b/README.md
@@ -227,7 +227,8 @@ This can be overwritten with the option `--ros-distro` allowing one to release f
 ## ROS beyond EoL
 
 For ROS distribution beyond EoL, `colcon in-container` integrates [Ubuntu Pro](https://ubuntu.com/pro) and [ROS ESM]
-(https://ubuntu.com/robotics/ros-esm) so you can benefit from security updates for 12 years!
+(https://ubuntu.com/robotics/ros-esm) so you can benefit from security updates for up to 12 years.
+Get your free Ubuntu Pro token at [ubuntu.com/pro/dashboard](https://ubuntu.com/pro/dashboard) and give it a shot.
 
 While EoL distro are limited in `colcon in-container` to use `pro`, you can get a free token on the
 [Ubuntu Pro dashboard](https://ubuntu.com/pro/dashboard).

--- a/README.md
+++ b/README.md
@@ -137,8 +137,8 @@ options:
   --provider {lxd, multipass}      Environment provider.
   --pro PRO_TOKEN       Ubuntu Pro token to enable ROS ESM inside the instance.
   --auto-deps-management
-                        Automatically manages missing dependencies.This will retrieve, install and source the ROS
-                        dependencies of the workspace not available in ROS ESM
+                        Automatically manages dependencies that are not covered by ROS ESM.
+                        Their source code is retrieved and compiled against ROS ESM.
 ```
 
 By default, `build-in-container` uses the ROS version from the `ROS_DISTRO` environment variable.
@@ -177,8 +177,8 @@ options:
   --provider {lxd, multipass}      Environment provider.
   --pro PRO_TOKEN       Ubuntu Pro token to enable ROS ESM inside the instance.
   --auto-deps-management
-                        Automatically manages missing dependencies.This will retrieve, install and source the ROS
-                        dependencies of the workspace not available in ROS ESM
+                        Automatically manages dependencies that are not covered by ROS ESM.
+                        Their source code is retrieved and compiled against ROS ESM.
 ```
 
 By default, buil and test `in-container` use the ROS version from the `ROS_DISTRO` environment variable.
@@ -217,8 +217,8 @@ options:
   --provider {lxd, multipass}      Environment provider.
   --pro PRO_TOKEN       Ubuntu Pro token to enable ROS ESM inside the instance.
   --auto-deps-management
-                        Automatically manages missing dependencies.This will retrieve, install and source the ROS
-                        dependencies of the workspace not available in ROS ESM
+                        Automatically manages dependencies that are not covered by ROS ESM.
+                        Their source code is retrieved and compiled against ROS ESM.
 ```
 
 By default, `release-in-container` uses the ROS version from the `ROS_DISTRO` environment variable.

--- a/README.md
+++ b/README.md
@@ -121,7 +121,8 @@ Usage help:
 ```
 $ colcon build-in-container --help
 
-usage: colcon build-in-container [-h] [--ros-distro ROS_DISTRO] [--colcon-build-args *] [--debug] [--shell-after] [--paths [PATH [PATH ...]]]
+usage: colcon build-in-container [-h] [--ros-distro ROS_DISTRO] [--colcon-build-args *] [--debug] [--shell-after]
+[--provider {lxd,multipass}] [--pro PRO] [--auto-deps-management]
 
 Call a colcon build command inside a fresh container.
 
@@ -134,6 +135,10 @@ options:
   --debug               Shell into the environment in case the build fails.
   --shell-after         Shell into the environment at the end of the build or if there is an error. This flag includes "--debug".
   --provider {lxd, multipass}      Environment provider.
+  --pro PRO             Ubuntu Pro token to enable inside the instance.
+  --auto-deps-management
+                        Automatically manages missing dependencies.This will retrieve, install and source the ROS
+                        dependencies of the workspace not available in ROS ESM
 ```
 
 By default, `build-in-container` uses the ROS version from the `ROS_DISTRO` environment variable.
@@ -155,7 +160,8 @@ Usage help:
 ```
 $ colcon test-in-container --help
 
-usage: colcon test-in-container [-h] [--ros-distro ROS_DISTRO] [--colcon-test-args *] [--debug] [--shell-after] [--paths [PATH [PATH ...]]]
+usage: colcon test-in-container [-h] [--ros-distro ROS_DISTRO] [--colcon-test-args *] [--debug] [--shell-after]
+[--provider {lxd,multipass}] [--pro PRO] [--auto-deps-management]
 
 Call a colcon test command inside a fresh container.
 
@@ -169,6 +175,10 @@ options:
   --shell-after         Shell into the environment at the end of the build or if there is an
                         error. This flag includes "--debug".
   --provider {lxd, multipass}      Environment provider.
+  --pro PRO             Ubuntu Pro token to enable inside the instance.
+  --auto-deps-management
+                        Automatically manages missing dependencies.This will retrieve, install and source the ROS
+                        dependencies of the workspace not available in ROS ESM
 ```
 
 By default, buil and test `in-container` use the ROS version from the `ROS_DISTRO` environment variable.
@@ -190,7 +200,8 @@ Usage help:
 ```
 $ colcon release-in-container --help
 
-usage: colcon release-in-container [-h] [--ros-distro ROS_DISTRO] [--bloom-generator {debian,rosdebian}] [--debug] [--shell-after] [--paths [PATH [PATH ...]]]
+usage: colcon release-in-container [-h] [--ros-distro ROS_DISTRO] [--bloom-generator {debian,rosdebian}] [--debug]
+[--shell-after] [--provider {lxd,multipass}] [--pro PRO] [--auto-deps-management]
 
 Generate Debian package inside a fresh container using bloom and fakeroot.
 
@@ -204,10 +215,40 @@ options:
   --debug               Shell into the environment in case the build fails.
   --shell-after         Shell into the environment at the end of the build or if there is an error. This flag includes "--debug".
   --provider {lxd, multipass}      Environment provider.
+  --pro PRO             Ubuntu Pro token to enable inside the instance.
+  --auto-deps-management
+                        Automatically manages missing dependencies.This will retrieve, install and source the ROS
+                        dependencies of the workspace not available in ROS ESM
 ```
 
 By default, `release-in-container` uses the ROS version from the `ROS_DISTRO` environment variable.
 This can be overwritten with the option `--ros-distro` allowing one to release for a different ROS distribution than the one associated with the host OS.
+
+## ROS beyond EoL
+
+For ROS distribution beyond EoL, `colcon in-container` integrates [Ubuntu Pro](https://ubuntu.com/pro) and [ROS ESM]
+(https://ubuntu.com/robotics/ros-esm) so you can benefit from security updates for 12 years!
+
+While EoL distro are limited in `colcon in-container` to use `pro`, you can get a free token on the
+[Ubuntu Pro dashboard](https://ubuntu.com/pro/dashboard).
+
+### `--pro`
+
+This flag will let you pass the mandatory Ubuntu Pro token and automatically enable
+[Ubuntu Pro](https://ubuntu.com/pro) and [ROS ESM](https://ubuntu.com/robotics/ros-esm).
+
+### `--auto-deps-management`
+
+This flag will enable the automatic dependencies management.
+
+ROS ESM covers up to the meta-package `ros-$DISTRO-ros-base`. Some ROS packages originally present in the ROS 
+repository might not be present in your workspace.
+With the help of the tool [`ros-esm-dependencies-diff-generator`](https://snapcraft.io/ros-esm-dependencies-diff-generator),
+the `--auto-deps-management` flag will take care of finding the dependencies, and installing them within the 
+isolated environment.
+
+At the end, the `build/` and `install/` directories of the `ws_underlay` containing the dependencies are downloaded on
+the host under: `build_in_container_underlay` and `install_in_container_underlay/`
 
 ## Use cases
 The colcon `in-container` extension can be used to:

--- a/colcon_in_container/providers/_helper.py
+++ b/colcon_in_container/providers/_helper.py
@@ -17,6 +17,7 @@ from platform import processor
 
 
 _ros2_ubuntu_distro = {'rolling': 'noble',
+                       'foxy': 'focal',
                        'humble': 'jammy',
                        'jazzy': 'noble'}
 

--- a/colcon_in_container/providers/config/cloud-init.yaml
+++ b/colcon_in_container/providers/config/cloud-init.yaml
@@ -27,6 +27,7 @@ packages:
   - python3
   - python3-colcon-common-extensions
   - python3-pip
+  - python3-venv
 
 write_files:
   - content: |
@@ -36,15 +37,20 @@ write_files:
       if [ -f /root/ws_underlay/install/setup.bash ]; then
         . /root/ws_underlay/install/setup.bash
       fi
+      if [ -f /root/.venv/bin/activate ]; then
+        . /root/.venv/bin/activate
+      fi
       cd /root/ws
     path: /root/.bashrc
     append: true
     defer: true
 runcmd:
+ - [set, -x]
+ - [mkdir, /root/ws]
+ - [python3, -m, venv, /root/.venv, --system-site-packages]
+ - [., /root/.venv/bin/activate]
  - [pip3, install, rosdep]
 {% if pro_token %}
  - [pip3, install , vcstool]
  - [mkdir, -p, /root/ws_underlay/src]
  {% endif %}
- - [mkdir, /root/ws]
- 

--- a/colcon_in_container/providers/config/cloud-init.yaml
+++ b/colcon_in_container/providers/config/cloud-init.yaml
@@ -33,11 +33,18 @@ write_files:
       if [ -f /opt/ros/*/setup.bash ]; then
         . /opt/ros/*/setup.bash
       fi
-      cd /ws
+      if [ -f /root/ws_underlay/install/setup.bash ]; then
+        . /root/ws_underlay/install/setup.bash
+      fi
+      cd /root/ws
     path: /root/.bashrc
     append: true
     defer: true
 runcmd:
  - [pip3, install, rosdep]
- - [mkdir, /ws]
+{% if pro_token %}
+ - [pip3, install , vcstool]
+ - [mkdir, -p, /root/ws_underlay/src]
+ {% endif %}
+ - [mkdir, /root/ws]
  

--- a/colcon_in_container/providers/config/cloud-init.yaml
+++ b/colcon_in_container/providers/config/cloud-init.yaml
@@ -1,13 +1,20 @@
 ## template: jinja
 #cloud-config
 
-{% set archmap={'x86_64':'amd64', 'aarch64':'arm64', 'armv7l': 'armhf', 'riscv64': 'riscv64'} %}
-
+{% if not pro_token %}
 apt:
   sources:
     ros2:
-      source: "deb [arch={{ archmap[v1.machine] }}] http://packages.ros.org/ros2/ubuntu {{ v1.distro_release }} main"
+      source: "deb [arch={{ architecture }}] http://packages.ros.org/ros2/ubuntu {{ distro_release }} main"
       keyid: C1CF 6E31 E6BA DE88 68B1 72B4 F42E D6FB AB17 C654
+{% else %}
+ubuntu_pro:
+  enable: [esm-apps, esm-infra, ros]
+  token: "{{ pro_token }}"
+snap:
+  commands:
+  - snap install ros-esm-dependencies-diff-generator --beta
+{% endif %}
 package_update: true
 package_upgrade: true
 
@@ -20,7 +27,6 @@ packages:
   - python3
   - python3-colcon-common-extensions
   - python3-pip
-  - python3-rosdep
 
 write_files:
   - content: |
@@ -32,5 +38,6 @@ write_files:
     append: true
     defer: true
 runcmd:
- - [ mkdir, /ws ]
+ - [pip3, install, rosdep]
+ - [mkdir, /ws]
  

--- a/colcon_in_container/providers/lxd.py
+++ b/colcon_in_container/providers/lxd.py
@@ -81,7 +81,6 @@ class LXDClient(Provider):
         }
         config['config']['user.user-data'] \
             = self._render_jinja_template(pro_token)
-        logger.error(config['config']['user.user-data'])
 
         if self.lxd_client.instances.exists(self.instance_name):
             previous_instance = self.lxd_client.instances.get(

--- a/colcon_in_container/providers/lxd.py
+++ b/colcon_in_container/providers/lxd.py
@@ -94,7 +94,8 @@ class LXDClient(Provider):
         self.instance = self.lxd_client.instances.create(config, wait=True)
         self.instance.start(wait=True)
 
-    def _clean_instance(self):
+    def clean_instance(self):
+        """Clean the created instance."""
         if hasattr(self, 'instance') and self.instance:
             if self.instance.status == 'Running':
                 self.instance.stop(wait=True)

--- a/colcon_in_container/providers/lxd.py
+++ b/colcon_in_container/providers/lxd.py
@@ -13,7 +13,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import jinja2
 import json
 import os
 from platform import system
@@ -29,7 +28,6 @@ from colcon_in_container.providers._helper \
     import host_architecture
 from colcon_in_container.providers.provider import Provider
 from pylxd import Client, exceptions as pylxd_exceptions
-
 
 
 def _is_lxd_installed():
@@ -81,7 +79,8 @@ class LXDClient(Provider):
             'ephemeral': True,
             'config': {},
         }
-        config['config']['user.user-data'] = self._render_jinja_template(pro_token)
+        config['config']['user.user-data'] \
+            = self._render_jinja_template(pro_token)
         logger.error(config['config']['user.user-data'])
 
         if self.lxd_client.instances.exists(self.instance_name):

--- a/colcon_in_container/providers/multipass.py
+++ b/colcon_in_container/providers/multipass.py
@@ -39,7 +39,7 @@ class MultipassClient(Provider):
                 'Multipass is not installed.'
                 'Please run `sudo snap install multipass`')
 
-        self._render_jinja_template(pro_token)
+        self._render_and_write_jinja_template(pro_token)
 
         if self._run(['info', self.instance_name]).returncode == 0:
             self._clean_instance()
@@ -86,7 +86,7 @@ class MultipassClient(Provider):
     def execute_command(self, command: List[str]):
         """Execute the given command inside the instance."""
         completed_process = self._run(['exec', self.instance_name,
-                                       '--working-directory', '/ws',
+                                       '--working-directory', '/root/ws',
                                        '--', 'sudo', *command],
                                       capture_output=True)
 

--- a/colcon_in_container/providers/multipass.py
+++ b/colcon_in_container/providers/multipass.py
@@ -96,8 +96,21 @@ class MultipassClient(Provider):
 
     def _copy_from_instance_to_host(self, *, instance_path, host_path):
         """Copy data from the instance to the host."""
+        temporary_instance_path = f'/home/ubuntu/{instance_path}'
+
+        move_return_code = self.execute_command([
+            f'mkdir -p {temporary_instance_path}'])
+
+        move_return_code &= self.execute_command([
+            f'cp -r {instance_path}/* {temporary_instance_path}'])
+
+        if move_return_code:
+            raise exceptions.FileNotFoundInInstanceError(
+                temporary_instance_path)
+
         command_result = self._run(['transfer', '--recursive', '--parents',
-                                    f'{self.instance_name}:{instance_path}',
+                                    f'{self.instance_name}:'
+                                    f'{temporary_instance_path}',
                                     host_path], check=True)
         if command_result.returncode:
             raise exceptions.FileNotFoundInInstanceError(instance_path)
@@ -148,6 +161,8 @@ class MultipassClient(Provider):
 
         move_return_code = self.execute_command([
             f'mv {temporary_instance_path}/* {instance_path}'])
+        move_return_code &= self.execute_command([
+            f'chown root:root -R {instance_path}'])
 
         if move_return_code:
             raise exceptions.FileNotFoundInInstanceError(

--- a/colcon_in_container/providers/multipass.py
+++ b/colcon_in_container/providers/multipass.py
@@ -42,7 +42,7 @@ class MultipassClient(Provider):
         self._render_and_write_jinja_template(pro_token)
 
         if self._run(['info', self.instance_name]).returncode == 0:
-            self._clean_instance()
+            self.clean_instance()
 
         cpus = os.getenv('COLCON_IN_CONTAINER_MULTIPASS_CPUS', default='2')
         mem = os.getenv('COLCON_IN_CONTAINER_MULTIPASS_MEMORY', default='4G')
@@ -80,7 +80,8 @@ class MultipassClient(Provider):
         logger.debug(f'Executing on host: {" ".join(command)}')
         return subprocess.run(command, **kwargs)
 
-    def _clean_instance(self):
+    def clean_instance(self):
+        """Clean the created instance."""
         self._run(['delete', '--purge', self.instance_name])
 
     def execute_command(self, command: List[str]):

--- a/colcon_in_container/providers/provider.py
+++ b/colcon_in_container/providers/provider.py
@@ -14,7 +14,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from abc import ABC, abstractmethod
-import jinja2
 import os
 from platform import machine
 import shutil
@@ -22,6 +21,7 @@ import shutil
 from colcon_in_container.logging import logger
 from colcon_in_container.providers import exceptions
 from colcon_in_container.providers._helper import get_ubuntu_distro
+import jinja2
 
 
 class Provider(ABC):
@@ -58,7 +58,7 @@ class Provider(ABC):
         elif host_architecture in ['ARM64', 'aarch64']:
             host_architecture = 'arm64'
         configuration = {'architecture': host_architecture,
-                    'distro_release': self.ubuntu_distro}
+                         'distro_release': self.ubuntu_distro}
         if pro_token:
             configuration['pro_token'] = pro_token
 
@@ -123,7 +123,7 @@ class Provider(ABC):
 
     def upload_package(self, package_name, package_path):
         """Upload package to instance workspace."""
-        instance_package_path = f'/ws/src/{package_name}'
+        instance_package_path = f'/root/ws/src/{package_name}'
         self.upload_directory(host_path=package_path,
                               instance_path=instance_package_path)
 

--- a/colcon_in_container/providers/provider.py
+++ b/colcon_in_container/providers/provider.py
@@ -33,11 +33,8 @@ class Provider(ABC):
         self.ubuntu_distro = get_ubuntu_distro(self.ros_distro)
         self.logger_instance = logger.getChild('instance')
 
-    def __del__(self):  # noqa: D105
-        self._clean_instance()
-
     @abstractmethod
-    def _clean_instance(self):
+    def clean_instance(self):
         """Clean the created instance."""
         pass
 

--- a/colcon_in_container/providers/provider_factory.py
+++ b/colcon_in_container/providers/provider_factory.py
@@ -40,12 +40,12 @@ class ProviderFactory(object):
         cls._providers[name] = provider
 
     @classmethod
-    def create(cls, name, ros_distro):
+    def create(cls, name, ros_distro, pro_token=None):
         """Make a provider based on the name."""
         provider = cls._providers.get(name)
         if not provider:
             raise exceptions.ProviderNotRegisteredError(name)
-        return provider(ros_distro)  # type: ignore
+        return provider(ros_distro, pro_token)  # type: ignore
 
 
 # Register all the providers

--- a/colcon_in_container/verb/_parser.py
+++ b/colcon_in_container/verb/_parser.py
@@ -92,7 +92,7 @@ def add_pro_arguments(parser):
     parser.add_argument(
         '--auto-deps-management',
         action='store_true',
-        help='Automatically manages missing dependencies.'
-             'This will retrieve, install and source the '
-             'ROS dependencies of the workspace not available in ROS ESM',
+        help='Automatically manages dependencies that are not covered by '
+             'ROS ESM.'
+             'Their source code is retrieved and compiled against ROS ESM.',
     )

--- a/colcon_in_container/verb/_parser.py
+++ b/colcon_in_container/verb/_parser.py
@@ -19,6 +19,7 @@ from colcon_in_container.logging import logger
 
 
 _ros_distro_choices = ['rolling', 'humble', 'jazzy']
+_eol_ros_distro_choices = ['foxy']
 
 
 def add_ros_distro_argument(parser):
@@ -29,7 +30,7 @@ def add_ros_distro_argument(parser):
         '--ros-distro',
         metavar='ROS_DISTRO',
         type=str,
-        choices=_ros_distro_choices,
+        choices=_ros_distro_choices+_eol_ros_distro_choices,
         default=ros_distro_env,
         required=not ros_distro_env,
         help='ROS version, can also be set by the environment variable '
@@ -39,11 +40,19 @@ def add_ros_distro_argument(parser):
 def verify_ros_distro_in_parsed_args(args):
     """Verify if the obtained ROS distro is matching the selection."""
     if args.ros_distro not in _ros_distro_choices:
-        logger.error(f'The ROS_DISTRO={args.ros_distro} '
+        if args.ros_distro in _eol_ros_distro_choices:
+            if not args.pro:
+                logger.error(f'The ros-distro is set to the EoL distro {args.ros_distro} '
+                     'without any Ubuntu Pro token provided.'
+                     'Please provide the `--pro` token argument'
+                     'in order to use EoL distro.')
+                return False
+        else:
+            logger.error(f'The ROS_DISTRO={args.ros_distro} '
                      'environment variable is not a viable '
                      '--ros-distro argument. See --ros-distro to set '
                      'a valid ros-distro')
-        return False
+            return False
     return True
 
 
@@ -67,4 +76,12 @@ def add_instance_argument(parser):
         choices=['lxd', 'multipass'],
         default='lxd',
         help='Environment provider.'
+    )
+
+def add_pro_argument(parser):
+    """Add the Ubuntu Pro token arguments to the parser."""
+    parser.add_argument(
+        '--pro',
+        type=str,
+        help='Ubuntu Pro token to enable inside the instance.',
     )

--- a/colcon_in_container/verb/_parser.py
+++ b/colcon_in_container/verb/_parser.py
@@ -84,8 +84,9 @@ def add_pro_arguments(parser):
     """Add the Ubuntu Pro token arguments to the parser."""
     parser.add_argument(
         '--pro',
+        metavar='PRO_TOKEN',
         type=str,
-        help='Ubuntu Pro token to enable inside the instance.',
+        help='Ubuntu Pro token to enable ROS ESM inside the instance.',
     )
 
     parser.add_argument(

--- a/colcon_in_container/verb/_parser.py
+++ b/colcon_in_container/verb/_parser.py
@@ -30,7 +30,7 @@ def add_ros_distro_argument(parser):
         '--ros-distro',
         metavar='ROS_DISTRO',
         type=str,
-        choices=_ros_distro_choices+_eol_ros_distro_choices,
+        choices=_ros_distro_choices + _eol_ros_distro_choices,
         default=ros_distro_env,
         required=not ros_distro_env,
         help='ROS version, can also be set by the environment variable '
@@ -42,16 +42,17 @@ def verify_ros_distro_in_parsed_args(args):
     if args.ros_distro not in _ros_distro_choices:
         if args.ros_distro in _eol_ros_distro_choices:
             if not args.pro:
-                logger.error(f'The ros-distro is set to the EoL distro {args.ros_distro} '
-                     'without any Ubuntu Pro token provided.'
-                     'Please provide the `--pro` token argument'
-                     'in order to use EoL distro.')
+                logger.error('The ros-distro is set to the EoL '
+                             'distro {args.ros_distro} '
+                             'without any Ubuntu Pro token provided.'
+                             'Please provide the `--pro` token argument'
+                             'in order to use EoL distro.')
                 return False
         else:
             logger.error(f'The ROS_DISTRO={args.ros_distro} '
-                     'environment variable is not a viable '
-                     '--ros-distro argument. See --ros-distro to set '
-                     'a valid ros-distro')
+                         'environment variable is not a viable '
+                         '--ros-distro argument. See --ros-distro to set '
+                         'a valid ros-distro')
             return False
     return True
 
@@ -78,10 +79,19 @@ def add_instance_argument(parser):
         help='Environment provider.'
     )
 
-def add_pro_argument(parser):
+
+def add_pro_arguments(parser):
     """Add the Ubuntu Pro token arguments to the parser."""
     parser.add_argument(
         '--pro',
         type=str,
         help='Ubuntu Pro token to enable inside the instance.',
+    )
+
+    parser.add_argument(
+        '--auto-deps-management',
+        action='store_true',
+        help='Automatically manages missing dependencies.'
+             'This will retrieve, install and source the '
+             'ROS dependencies of the workspace not available in ROS ESM',
     )

--- a/colcon_in_container/verb/_pro.py
+++ b/colcon_in_container/verb/_pro.py
@@ -1,0 +1,48 @@
+# Copyright (C) 2023 Canonical, Ltd.
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from typing import Optional, Set
+
+from colcon_in_container.logging import logger
+
+
+class Pro(object):
+    """Pro tool class wrapper to call pro in a provider."""
+
+    def __init__(self, provider, token):
+        """Initialize rosdep and call rosdep init."""
+        self.provider = provider
+        logger.info('Attaching Pro token')
+        #TODO We should not let people enable pro when it's not available
+        #TODO We should not enable ROS 2 sources that are enabled in the cloud-init
+        # Should we use a different jinja or make it more complex?
+        #TODO do we want to integrate rosinstall_generator?
+        
+        self.provider.execute_command(['pro', 'attach', token])
+
+    def enable(self):
+        """Call Pro enable for ROS ESM."""
+        logger.info('Enabling ROS ESM')
+        commands = [
+            'pro enable esm-infra',
+            'pro enable esm-apps',
+            'apt-get update',
+            'apt-get upgrade -y',
+            'pro enable ros --beta',
+            #TODO This should depends on a flag
+            'pro enable ros-updates --beta' 
+            
+        ]
+        return self.provider.execute_commands(commands)

--- a/colcon_in_container/verb/_rosdep.py
+++ b/colcon_in_container/verb/_rosdep.py
@@ -37,13 +37,15 @@ class Rosdep(object):
             commands.append('--include-eol-distros')
         return self.provider.execute_command(commands)
 
-    def install(self, dependency_types: Optional[Set[str]] = None):
+    def install(self,
+                workspace='/root/ws/src',
+                dependency_types: Optional[Set[str]] = None):
         """Call rosdep install on the provided dependency_types."""
         logger.info('Installing dependencies with rosdep')
         commands = [
             # Avoid rosdep/apt interactive shell error message
             'export DEBIAN_FRONTEND=noninteractive',
-            'rosdep install --from-paths /ws/src --ignore-src -y '
+            f'rosdep install --from-paths {workspace} --ignore-src -y '
             f'--rosdistro={self.ros_distro} '
         ]
         if dependency_types:

--- a/colcon_in_container/verb/_rosdep.py
+++ b/colcon_in_container/verb/_rosdep.py
@@ -16,6 +16,7 @@
 from typing import Optional, Set
 
 from colcon_in_container.logging import logger
+from colcon_in_container.verb._parser import _eol_ros_distro_choices
 
 
 class Rosdep(object):
@@ -31,7 +32,10 @@ class Rosdep(object):
     def update(self):
         """Call rosdep update."""
         logger.info('Updating rosdep')
-        return self.provider.execute_command(['rosdep', 'update'])
+        commands = ['rosdep', 'update']
+        if self.ros_distro in _eol_ros_distro_choices:
+            commands.append('--include-eol-distros')
+        return self.provider.execute_command(commands)
 
     def install(self, dependency_types: Optional[Set[str]] = None):
         """Call rosdep install on the provided dependency_types."""

--- a/colcon_in_container/verb/_rosdep.py
+++ b/colcon_in_container/verb/_rosdep.py
@@ -27,15 +27,15 @@ class Rosdep(object):
         self.provider = provider
         self.ros_distro = ros_distro
         logger.info('Initialising rosdep')
-        self.provider.execute_command(['rosdep', 'init'])
+        self.provider.execute_commands(['rosdep init'])
 
     def update(self):
         """Call rosdep update."""
         logger.info('Updating rosdep')
-        commands = ['rosdep', 'update']
+        command = 'rosdep update'
         if self.ros_distro in _eol_ros_distro_choices:
-            commands.append('--include-eol-distros')
-        return self.provider.execute_command(commands)
+            command += ' --include-eol-distros'
+        return self.provider.execute_commands([command])
 
     def install(self,
                 workspace='/root/ws/src',

--- a/colcon_in_container/verb/build_in_container.py
+++ b/colcon_in_container/verb/build_in_container.py
@@ -135,4 +135,6 @@ class BuildInContainerVerb(InContainer):
             logger.info('Shell after was selected, entering the instance.')
             self.provider.shell()
 
+        self.provider.clean_instance()
+
         return exit_code

--- a/colcon_in_container/verb/build_in_container.py
+++ b/colcon_in_container/verb/build_in_container.py
@@ -121,7 +121,6 @@ class BuildInContainerVerb(InContainer):
             self._upload_selected_packages(decorators)
 
             exit_code = self._build(context.args)
-            logger.error(f'here is the build exit code: {exit_code}')
 
         if exit_code != 0:
             logger.error(f'Build failed with exit code {exit_code}. ')

--- a/colcon_in_container/verb/build_in_container.py
+++ b/colcon_in_container/verb/build_in_container.py
@@ -26,6 +26,7 @@ from colcon_in_container.providers import exceptions as provider_exceptions
 from colcon_in_container.providers.provider_factory import ProviderFactory
 from colcon_in_container.verb._parser import \
     add_instance_argument, add_ros_distro_argument, \
+    add_pro_argument, \
     verify_ros_distro_in_parsed_args
 from colcon_in_container.verb._rosdep import Rosdep
 from colcon_in_container.verb.in_container import InContainer
@@ -52,6 +53,7 @@ class BuildInContainerVerb(InContainer):
 
         add_instance_argument(parser)
         add_packages_arguments(parser)
+        add_pro_argument(parser)
 
     def _colcon_build(self, colcon_build_args):
         logger.info(f'building workspace with args: {colcon_build_args}')
@@ -97,7 +99,9 @@ class BuildInContainerVerb(InContainer):
             sys.exit(1)
 
         self.provider = ProviderFactory.create(context.args.provider,
-                                               context.args.ros_distro)
+                                               context.args.ros_distro,
+                                               context.args.pro)
+
         try:
             self.provider.wait_for_install()
         except provider_exceptions.CloudInitError as e:

--- a/colcon_in_container/verb/build_in_container.py
+++ b/colcon_in_container/verb/build_in_container.py
@@ -25,8 +25,8 @@ from colcon_in_container.logging import logger
 from colcon_in_container.providers import exceptions as provider_exceptions
 from colcon_in_container.providers.provider_factory import ProviderFactory
 from colcon_in_container.verb._parser import \
-    add_instance_argument, add_ros_distro_argument, \
-    add_pro_argument, \
+    add_instance_argument, add_pro_arguments, \
+    add_ros_distro_argument, \
     verify_ros_distro_in_parsed_args
 from colcon_in_container.verb._rosdep import Rosdep
 from colcon_in_container.verb.in_container import InContainer
@@ -37,6 +37,11 @@ class BuildInContainerVerb(InContainer):
 
     def __init__(self):  # noqa: D107
         super().__init__()
+        self.dependency_types = {'build',
+                                 'buildtool',
+                                 'build_export',
+                                 'buildtool_export',
+                                 'test'}
 
     def add_arguments(self, *, parser):  # noqa: D102
 
@@ -53,7 +58,7 @@ class BuildInContainerVerb(InContainer):
 
         add_instance_argument(parser)
         add_packages_arguments(parser)
-        add_pro_argument(parser)
+        add_pro_arguments(parser)
 
     def _colcon_build(self, colcon_build_args):
         logger.info(f'building workspace with args: {colcon_build_args}')
@@ -68,12 +73,9 @@ class BuildInContainerVerb(InContainer):
         result build directory.
         """
         commands: List[Callable[[], int]] = [
+            partial(self._ros_esm, args),
             partial(self.rosdep.install,
-                    {'build',
-                     'buildtool',
-                     'build_export',
-                     'buildtool_export',
-                     'test'}),
+                    dependency_types=self.dependency_types),
             partial(self._colcon_build, args.colcon_build_args)]
         for command in commands:
             exit_code = command()
@@ -117,12 +119,14 @@ class BuildInContainerVerb(InContainer):
             logger.info(f'Discovered {len(decorators)} packages, '
                         'uploading them in the instance')
             self._upload_selected_packages(decorators)
+
             exit_code = self._build(context.args)
+            logger.error(f'here is the build exit code: {exit_code}')
 
         if exit_code != 0:
             logger.error(f'Build failed with exit code {exit_code}. ')
             if context.args.debug:
-                logger.warn('Debug was selected, entering the instance.')
+                logger.warning('Debug was selected, entering the instance.')
                 self.provider.shell()
         else:
             logger.info('Successfully built workspace in container.')

--- a/colcon_in_container/verb/in_container.py
+++ b/colcon_in_container/verb/in_container.py
@@ -18,6 +18,9 @@ from typing import List
 
 from colcon_core.plugin_system import satisfies_version
 from colcon_core.verb import VerbExtensionPoint
+from colcon_in_container.verb._pro import \
+    auto_ros_esm_dependency_management, \
+    underlay_workspace_path
 
 
 class InContainer(ABC, VerbExtensionPoint):
@@ -28,9 +31,11 @@ class InContainer(ABC, VerbExtensionPoint):
         satisfies_version(VerbExtensionPoint.EXTENSION_POINT_VERSION, '^1.0')
         self.host_build_in_container_folder = 'build_in_container'
         self.host_install_in_container_folder = 'install_in_container'
+        self.host_build_underlay_folder = 'build_in_container_underlay'
+        self.host_install_underlay_folder = 'install_in_container_underlay'
         self.host_test_results_folder = 'test_results_in_container'
         self.host_release_in_container_folder = 'release_in_container'
-        self.instance_workspace_path = '/ws/'
+        self.instance_workspace_path = '/root/ws/'
 
     def _upload_selected_packages(self, package_decorators) -> List[str]:
         """Upload selected packages in the instance.
@@ -45,3 +50,19 @@ class InContainer(ABC, VerbExtensionPoint):
             self.provider.upload_package(package.name, package.path)
             package_names.append(package.name)
         return package_names
+
+    def _ros_esm(self, args):
+        if args.pro and args.auto_deps_management:
+            auto_ros_esm_dependency_management(self.provider,
+                                               self.rosdep,
+                                               args.ros_distro,
+                                               self.dependency_types)
+            self.provider.download_result(
+                result_path_in_instance=underlay_workspace_path
+                + 'install',
+                result_path_on_host=self.host_install_underlay_folder)
+            self.provider.download_result(
+                result_path_in_instance=underlay_workspace_path
+                + 'build',
+                result_path_on_host=self.host_build_underlay_folder
+            )

--- a/colcon_in_container/verb/in_container.py
+++ b/colcon_in_container/verb/in_container.py
@@ -18,6 +18,7 @@ from typing import List
 
 from colcon_core.plugin_system import satisfies_version
 from colcon_core.verb import VerbExtensionPoint
+from colcon_in_container.logging import logger
 from colcon_in_container.verb._pro import \
     auto_ros_esm_dependency_management, \
     underlay_workspace_path
@@ -53,16 +54,22 @@ class InContainer(ABC, VerbExtensionPoint):
 
     def _ros_esm(self, args):
         if args.pro and args.auto_deps_management:
-            auto_ros_esm_dependency_management(self.provider,
-                                               self.rosdep,
-                                               args.ros_distro,
-                                               self.dependency_types)
-            self.provider.download_result(
-                result_path_in_instance=underlay_workspace_path
-                + 'install',
-                result_path_on_host=self.host_install_underlay_folder)
-            self.provider.download_result(
-                result_path_in_instance=underlay_workspace_path
-                + 'build',
-                result_path_on_host=self.host_build_underlay_folder
-            )
+            try:
+                auto_ros_esm_dependency_management(self.provider,
+                                                   self.rosdep,
+                                                   args.ros_distro,
+                                                   self.dependency_types)
+
+                self.provider.download_result(
+                    result_path_in_instance=underlay_workspace_path
+                    + 'install',
+                    result_path_on_host=self.host_install_underlay_folder)
+                self.provider.download_result(
+                    result_path_in_instance=underlay_workspace_path
+                    + 'build',
+                    result_path_on_host=self.host_build_underlay_folder
+                )
+            except SystemError as e:
+                logger.error(f'Failed top create underlay workspace: {e}')
+                return 1
+        return 0

--- a/colcon_in_container/verb/release_in_container.py
+++ b/colcon_in_container/verb/release_in_container.py
@@ -26,9 +26,10 @@ from colcon_in_container.logging import logger
 from colcon_in_container.providers import exceptions as provider_exceptions
 from colcon_in_container.providers.provider_factory import ProviderFactory
 from colcon_in_container.verb._parser import \
-    add_instance_argument, add_ros_distro_argument, \
-    add_pro_argument, \
+    add_instance_argument, add_pro_arguments, \
+    add_ros_distro_argument, \
     verify_ros_distro_in_parsed_args
+from colcon_in_container.verb._pro import auto_ros_esm_dependency_management
 from colcon_in_container.verb._rosdep import Rosdep
 from colcon_in_container.verb.in_container import InContainer
 
@@ -38,13 +39,18 @@ class ReleaseInContainerVerb(InContainer):
 
     def __init__(self):  # noqa: D107
         super().__init__()
+        self.dependency_types = {'build',
+                                 'buildtool',
+                                 'build_export',
+                                 'buildtool_export',
+                                 'test'}
 
     def add_arguments(self, *, parser):  # noqa: D102
 
         add_ros_distro_argument(parser)
         add_instance_argument(parser)
         add_packages_arguments(parser)
-        add_pro_argument(parser)
+        add_pro_arguments(parser)
 
         parser.add_argument(
             '--bloom-generator',
@@ -79,23 +85,26 @@ class ReleaseInContainerVerb(InContainer):
     def _bloom_generate(self, package_name, generator):
         logger.info(f'Bloom generating {package_name}')
         return self.provider.execute_commands([
-            f'cd /ws/src/{package_name}',
+            f'cd {self.instance_workspace_path}/src/{package_name}',
             f'bloom-generate {generator}'])
 
     def _generate_binary(self, package_name):
         logger.info(f'Generating binary for {package_name}')
         return self.provider.execute_commands([
-            f'cd /ws/src/{package_name}',
+            f'cd {self.instance_workspace_path}/src/{package_name}',
             'fakeroot debian/rules binary'])
 
     def _save_results(self, package_name):
         logger.info(f'Saving results for {package_name}')
         return self.provider.execute_commands([
-            f'mkdir -p /ws/release/{package_name}',
-            f'mv /ws/src/{package_name}/debian /ws/release/{package_name}',
-            f'mv /ws/src/*.deb /ws/release/{package_name}',
+            f'mkdir -p {self.instance_workspace_path}/release/{package_name}',
+            f'mv {self.instance_workspace_path}/src/{package_name}/debian '
+            f'{self.instance_workspace_path}/release/{package_name}',
+            f'mv {self.instance_workspace_path}/src/*.deb '
+            f'{self.instance_workspace_path}/release/{package_name}',
             # not every package have .ddeb file
-            f'mv /ws/src/*.ddeb /ws/release/{package_name} || true'])
+            f'mv {self.instance_workspace_path}/src/*.ddeb '
+            f'{self.instance_workspace_path}/release/{package_name} || true'])
 
     def _add_colcon_ignore(self):
         """Add COLCON_IGNORE to the results.
@@ -116,11 +125,7 @@ class ReleaseInContainerVerb(InContainer):
         """
         commands: List[Callable[[], int]] = [
             partial(self.rosdep.install,
-                    {'build',
-                     'buildtool',
-                     'build_export',
-                     'buildtool_export',
-                     'test'}),
+                    dependency_types=self.dependency_types),
             partial(self._bloom_generate, package_name, args.bloom_generator),
             partial(self._generate_binary, package_name),
             partial(self._save_results, package_name)]
@@ -157,7 +162,8 @@ class ReleaseInContainerVerb(InContainer):
             sys.exit(1)
 
         self.provider = ProviderFactory.create(context.args.provider,
-                                               context.args.ros_distro)
+                                               context.args.ros_distro,
+                                               context.args.pro)
         try:
             self.provider.wait_for_install()
 
@@ -178,6 +184,12 @@ class ReleaseInContainerVerb(InContainer):
             package_names = self._upload_selected_packages(decorators)
             if not package_names:
                 raise FileNotFoundError('No package found for release')
+
+            if context.args.pro and context.args.auto_deps_management:
+                auto_ros_esm_dependency_management(self.provider,
+                                                   self.rosdep,
+                                                   context.args.ros_distro,
+                                                   self.dependency_types)
 
             for package in package_names:
                 try:

--- a/colcon_in_container/verb/release_in_container.py
+++ b/colcon_in_container/verb/release_in_container.py
@@ -217,4 +217,6 @@ class ReleaseInContainerVerb(InContainer):
             logger.info('Shell after was selected, entering the instance')
             self.provider.shell()
 
+        self.provider.clean_instance()
+
         sys.exit(0)

--- a/colcon_in_container/verb/release_in_container.py
+++ b/colcon_in_container/verb/release_in_container.py
@@ -27,6 +27,7 @@ from colcon_in_container.providers import exceptions as provider_exceptions
 from colcon_in_container.providers.provider_factory import ProviderFactory
 from colcon_in_container.verb._parser import \
     add_instance_argument, add_ros_distro_argument, \
+    add_pro_argument, \
     verify_ros_distro_in_parsed_args
 from colcon_in_container.verb._rosdep import Rosdep
 from colcon_in_container.verb.in_container import InContainer
@@ -43,6 +44,7 @@ class ReleaseInContainerVerb(InContainer):
         add_ros_distro_argument(parser)
         add_instance_argument(parser)
         add_packages_arguments(parser)
+        add_pro_argument(parser)
 
         parser.add_argument(
             '--bloom-generator',

--- a/colcon_in_container/verb/test_in_container.py
+++ b/colcon_in_container/verb/test_in_container.py
@@ -135,4 +135,6 @@ class TestInContainerVerb(InContainer):
             logger.info('Shell after was selected, entering the instance.')
             self.provider.shell()
 
+        self.provider.clean_instance()
+
         return exit_code

--- a/colcon_in_container/verb/test_in_container.py
+++ b/colcon_in_container/verb/test_in_container.py
@@ -26,6 +26,7 @@ from colcon_in_container.providers import exceptions as provider_exceptions
 from colcon_in_container.providers.provider_factory import ProviderFactory
 from colcon_in_container.verb._parser import \
     add_instance_argument, add_ros_distro_argument, \
+    add_pro_argument,\
     verify_ros_distro_in_parsed_args
 from colcon_in_container.verb._rosdep import Rosdep
 from colcon_in_container.verb.in_container import InContainer
@@ -54,6 +55,7 @@ class TestInContainerVerb(InContainer):
 
         add_instance_argument(parser)
         add_packages_arguments(parser)
+        add_pro_argument(parser)
 
     def _colcon_test(self, colcon_test_args):
         logger.info(f'testing workspace with args: {colcon_test_args}')

--- a/colcon_in_container/verb/test_in_container.py
+++ b/colcon_in_container/verb/test_in_container.py
@@ -25,8 +25,8 @@ from colcon_in_container.logging import logger
 from colcon_in_container.providers import exceptions as provider_exceptions
 from colcon_in_container.providers.provider_factory import ProviderFactory
 from colcon_in_container.verb._parser import \
-    add_instance_argument, add_ros_distro_argument, \
-    add_pro_argument,\
+    add_instance_argument, add_pro_arguments, \
+    add_ros_distro_argument, \
     verify_ros_distro_in_parsed_args
 from colcon_in_container.verb._rosdep import Rosdep
 from colcon_in_container.verb.in_container import InContainer
@@ -39,6 +39,7 @@ class TestInContainerVerb(InContainer):
 
     def __init__(self):  # noqa: D107
         super().__init__()
+        self.dependency_types = {'exec', 'test'}
 
     def add_arguments(self, *, parser):  # noqa: D102
 
@@ -55,7 +56,7 @@ class TestInContainerVerb(InContainer):
 
         add_instance_argument(parser)
         add_packages_arguments(parser)
-        add_pro_argument(parser)
+        add_pro_arguments(parser)
 
     def _colcon_test(self, colcon_test_args):
         logger.info(f'testing workspace with args: {colcon_test_args}')
@@ -70,8 +71,9 @@ class TestInContainerVerb(InContainer):
         result test directories.
         """
         commands: List[Callable[[], int]] = [
+            partial(self._ros_esm, args),
             partial(self.rosdep.install,
-                    {'exec', 'test'}),
+                    dependency_types=self.dependency_types),
             partial(self._colcon_test, args.colcon_test_args)]
         for command in commands:
             exit_code = command()
@@ -93,7 +95,8 @@ class TestInContainerVerb(InContainer):
             sys.exit(1)
 
         self.provider = ProviderFactory.create(context.args.provider,
-                                               context.args.ros_distro)
+                                               context.args.ros_distro,
+                                               context.args.pro)
 
         try:
             self.provider.wait_for_install()

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -2,6 +2,7 @@ aarch
 abstractmethod
 apache
 buildtool
+chown
 cmake
 colcon
 cpus

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -9,7 +9,9 @@ dcmake
 ddeb
 debhelper
 debian
+deps
 distro
+distros
 fakeroot
 filepath
 firewalld
@@ -45,9 +47,11 @@ rmtree
 rosdebian
 rosdep
 rosdistro
+rosinstall
 scspell
 setuptools
 simplestreams
+snapcraft
 sudo
 symlink
 thomas


### PR DESCRIPTION
This pull request re-nable the EoL ROS 2 distro when a `--pro` token is provided.
Ubuntu Pro enables ROS ESM to benefit from security maintenance beyond EoL.


This PR also solves: https://github.com/canonical/colcon-in-container/issues/36


List of improvements:
- Adds a `--pro` token flag
- Enable ROS 2 Foxy back when `--pro` is specified
- Install rosdep from pip so we have the same version with the same options everywhere
- Manually clean instances instead of relying on destructor and garbage collector.
- Improve multipass vm import and export (transfer) to support more cases
- Adds an `--auto-deps-management` so dependencies from the workspace not present in ROS ESM are automatically managed.
- Adds a CI for Foxy with Ubuntu Pro