### PR TITLE
Feat/install debs during release

### DIFF
--- a/.github/workflows/colcon_in_container.yaml
+++ b/.github/workflows/colcon_in_container.yaml
@@ -152,16 +152,17 @@ jobs:
         run: |
           cd ros_ws
           grep "Hostname=\"colcon-in-container\"" test_results_in_container/pendulum_control/Testing/*/Test.xml
-      ## commented due to https://github.com/canonical/colcon-in-container/issues/25
-      # - name: Colcon release in container
-      #   run: |
-      #     cd ros_ws
-      #     colcon --log-level=debug release-in-container --pro ${{ secrets.PRO_TOKEN }} --auto-deps-management --provider ${{ matrix.provider}} --ros-distro ${{ matrix.ros_version }} --packages-select pendulum_control --bloom-generator="rosdebian"
-      # - name: Colcon release in container verify files
-      #   run: |
-      #     cd ros_ws
-      #     ls release_in_container/demo_nodes_cpp/ros-${{ matrix.ros_version }}-demo-nodes-cpp_*.deb
-      #     ls release_in_container/demo_nodes_cpp/ros-${{ matrix.ros_version }}-demo-nodes-cpp-dbgsym_*.ddeb
-      #     ls release_in_container/COLCON_IGNORE
-      #     ls release_in_container/demo_nodes_cpp/debian
+      - name: Colcon release in container
+        run: |
+          cd ros_ws
+          colcon --log-level=debug release-in-container --pro ${{ secrets.PRO_TOKEN }} --auto-deps-management --provider ${{ matrix.provider}} --ros-distro ${{ matrix.ros_version }} --packages-select pendulum_msgs pendulum_control --bloom-generator="rosdebian" --install-debs
+      - name: Colcon release in container verify files
+        run: |
+          cd ros_ws
+          ls release_in_container/pendulum_msgs/ros-${{ matrix.ros_version }}-pendulum-msgs_*.deb
+          ls release_in_container/pendulum_control/ros-${{ matrix.ros_version }}-pendulum-control_*.deb
+          ls release_in_container/pendulum_control/ros-${{ matrix.ros_version }}-pendulum-control-dbgsym_*.ddeb
+          ls release_in_container/COLCON_IGNORE
+          ls release_in_container/pendulum_msgs/debian
+          ls release_in_container/pendulum_control/debian
 

--- a/.github/workflows/colcon_in_container.yaml
+++ b/.github/workflows/colcon_in_container.yaml
@@ -155,7 +155,7 @@ jobs:
       - name: Colcon release in container
         run: |
           cd ros_ws
-          colcon --log-level=debug release-in-container --pro ${{ secrets.PRO_TOKEN }} --auto-deps-management --provider ${{ matrix.provider}} --ros-distro ${{ matrix.ros_version }} --packages-select pendulum_msgs pendulum_control --bloom-generator="rosdebian" --install-debs
+          colcon --log-level=debug release-in-container --pro ${{ secrets.PRO_TOKEN }} --auto-deps-management --provider ${{ matrix.provider}} --ros-distro ${{ matrix.ros_version }} --packages-select pendulum_msgs pendulum_control --bloom-generator="rosdebian" --install-released-packages
       - name: Colcon release in container verify files
         run: |
           cd ros_ws

--- a/README.md
+++ b/README.md
@@ -219,10 +219,13 @@ options:
   --auto-deps-management
                         Automatically manages dependencies that are not covered by ROS ESM.
                         Their source code is retrieved and compiled against ROS ESM.
+  --install-debs        Install the released packages so they are available.
 ```
 
 By default, `release-in-container` uses the ROS version from the `ROS_DISTRO` environment variable.
 This can be overwritten with the option `--ros-distro` allowing one to release for a different ROS distribution than the one associated with the host OS.
+
+The `--install-debs` flag automatically install the released packages in the system. This way they are available if the next packages to release have them as dependencies.
 
 ## ROS beyond EoL
 

--- a/README.md
+++ b/README.md
@@ -219,13 +219,14 @@ options:
   --auto-deps-management
                         Automatically manages dependencies that are not covered by ROS ESM.
                         Their source code is retrieved and compiled against ROS ESM.
-  --install-debs        Install the released packages so they are available.
+  --install-released-packages        Progressively install released packages so that dependencies are satisfied.
 ```
 
 By default, `release-in-container` uses the ROS version from the `ROS_DISTRO` environment variable.
 This can be overwritten with the option `--ros-distro` allowing one to release for a different ROS distribution than the one associated with the host OS.
 
-The `--install-debs` flag automatically install the released packages in the system. This way they are available if the next packages to release have them as dependencies.
+The `--install-released-packages` flag automatically installs the packages as they are released,
+ensuring that local dependencies are satisfied.
 
 ## ROS beyond EoL
 

--- a/colcon_in_container/verb/release_in_container.py
+++ b/colcon_in_container/verb/release_in_container.py
@@ -231,7 +231,7 @@ class ReleaseInContainerVerb(InContainer):
                                       f'failed: {str(e)}')
                 logger.info(f'Package {package} released!')
 
-                if context.args.install_debs:
+                if context.args.install_released_packages:
                     logger.info(f'Installing {package} package.')
                     self._install_package(package)
 

--- a/colcon_in_container/verb/release_in_container.py
+++ b/colcon_in_container/verb/release_in_container.py
@@ -63,9 +63,10 @@ class ReleaseInContainerVerb(InContainer):
         )
 
         parser.add_argument(
-            '--install-debs',
+            '--install-released-packages',
             action='store_true',
-            help='Install the released packages so they are available.',
+            help='Progressively install released packages '
+                 'so that dependencies are satisfied.',
         )
 
     def _install_bloom_dependencies(self, ros_distro):

--- a/colcon_in_container/verb/release_in_container.py
+++ b/colcon_in_container/verb/release_in_container.py
@@ -44,6 +44,7 @@ class ReleaseInContainerVerb(InContainer):
                                  'build_export',
                                  'buildtool_export',
                                  'test'}
+        self.packages_from_underlay_ws = []
 
     def add_arguments(self, *, parser):  # noqa: D102
 
@@ -59,6 +60,12 @@ class ReleaseInContainerVerb(InContainer):
             choices=['debian', 'rosdebian'],
             required=False,
             help='Pass arguments to the bloom-generate command.',
+        )
+
+        parser.add_argument(
+            '--install-debs',
+            action='store_true',
+            help='Install the released packages so they are available.',
         )
 
     def _install_bloom_dependencies(self, ros_distro):
@@ -156,6 +163,27 @@ class ReleaseInContainerVerb(InContainer):
         # from release won't get detected
         self._add_colcon_ignore()
 
+    def _install_package(self, package_name):
+        """Install the package on the system.
+
+        Install the package on the system so it's available for
+        the packages to be released.
+        For now, only Debian packages are supported.
+
+        Raise: ChildProcessError when the installation fails.
+        """
+        package_to_install = (f'{self.instance_workspace_path}/release/'
+                              f'{package_name}/*.deb')
+        logger.debug(f'Installing {package_to_install} file.')
+        # We ignore the dependencies so the packages from the
+        # underlay workspace are not causing a
+        # missing dependency error.
+        exit_code = self.provider.execute_commands([
+            f'dpkg --install --force-depends {package_to_install}'])
+        if exit_code:
+            raise ChildProcessError('Failed to install released '
+                                    f'package {package_name}: {exit_code}')
+
     def main(self, *, context):  # noqa: D102
 
         if not verify_ros_distro_in_parsed_args(context.args):
@@ -202,14 +230,19 @@ class ReleaseInContainerVerb(InContainer):
                                       f'failed: {str(e)}')
                 logger.info(f'Package {package} released!')
 
+                if context.args.install_debs:
+                    logger.info(f'Installing {package} package.')
+                    self._install_package(package)
+
             self._download_packages_results()
 
-        except (SystemError,
+        except (ChildProcessError,
+                SystemError,
                 FileNotFoundError,
                 provider_exceptions.CloudInitError) as e:
             logger.error(str(e))
             if context.args.debug or context.args.shell_after:
-                logger.warn('Debug was selected, entering the instance')
+                logger.warning('Debug was selected, entering the instance')
                 self.provider.shell()
                 sys.exit(1)
 

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -13,6 +13,7 @@ debian
 deps
 distro
 distros
+dpkg
 fakeroot
 filepath
 firewalld


### PR DESCRIPTION
Solves: https://github.com/canonical/colcon-in-container/issues/25

This PR integrates:
- A new flag `--install-debs` available for `release-in-container` so released packages are installed in the instance
- Enables the CI for Pro and `release-in-container` using the new flag