### PR TITLE
ci: remove Ubuntu 20.04 runner

### DIFF
--- a/.github/workflows/colcon_in_container.yaml
+++ b/.github/workflows/colcon_in_container.yaml
@@ -15,12 +15,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, [self-hosted, linux, X64, jammy, xlarge]]
+        os: [ubuntu-22.04, ubuntu-24.04, [self-hosted, linux, X64, jammy, xlarge]]
         ros_version: [jazzy, humble, rolling]
         provider: [lxd, multipass]
         exclude:
-          - os: ubuntu-20.04
-            provider: multipass
           - os: ubuntu-22.04
             provider: multipass
           - os: ubuntu-24.04


### PR DESCRIPTION
Remove the Ubuntu 20.04 runner from the CI.

The GH runner is no longer available.