### PR TITLE
feat: enable resolute and lyrical

### DIFF
--- a/.github/workflows/colcon_in_container.yaml
+++ b/.github/workflows/colcon_in_container.yaml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04, [self-hosted, linux, X64, jammy, xlarge]]
-        ros_version: [jazzy, humble, kilted, rolling]
+        ros_version: [jazzy, humble, kilted, lyrical, rolling]
         provider: [lxd, multipass]
         exclude:
           - os: ubuntu-22.04

--- a/.github/workflows/colcon_in_container.yaml
+++ b/.github/workflows/colcon_in_container.yaml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/setup-python@v5
       - name: Install LXD
         if: ${{ matrix.provider == 'lxd' }}
-        uses: canonical/setup-lxd@v0.1.0
+        uses: canonical/setup-lxd@v1
       - name: Install Multipass
         run: |
           sudo snap install multipass
@@ -107,7 +107,7 @@ jobs:
       - uses: actions/setup-python@v5
       - name: Install LXD
         if: ${{ matrix.provider == 'lxd' }}
-        uses: canonical/setup-lxd@v0.1.0
+        uses: canonical/setup-lxd@v1
       - name: Install Multipass
         run: |
           sudo snap install multipass

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ lxd init --auto
 
 - Then call colcon with the build-in-container verb:
 ```
-colcon --log-level=info build-in-container --ros-distro jazzy
+colcon --log-level=info build-in-container --ros-distro lyrical
 ```
 
 See the [usage](#usage) section for advanced information on installation and tool usage.
@@ -113,9 +113,9 @@ To use a [remote LXD server](https://documentation.ubuntu.com/lxd/latest/remotes
 3. Use the `--remote` flag with `colcon-in-container`:
    ```
    # You can use either the remote name or the URL
-   colcon build-in-container --remote my-remote --ros-distro jazzy
+   colcon build-in-container --remote my-remote --ros-distro lyrical
    # OR
-   colcon build-in-container --remote https://remote-server-ip:8443 --ros-distro jazzy
+   colcon build-in-container --remote https://remote-server-ip:8443 --ros-distro lyrical
    ```
 
 The tool will automatically use the client certificates for authentication with the remote LXD server.
@@ -147,7 +147,7 @@ colcon build-in-container
 
 Advanced usage:
 ```
-colcon --log-level=info build-in-container --ros-distro jazzy --colcon-build-args "--cmake-args -DCMAKE_BUILD_TYPE=Release" --debug
+colcon --log-level=info build-in-container --ros-distro lyrical --colcon-build-args "--cmake-args -DCMAKE_BUILD_TYPE=Release" --debug
 ```
 
 Usage help:
@@ -189,7 +189,7 @@ colcon test-in-container
 
 Advanced usage:
 ```
-colcon --log-level=info test-in-container --ros-distro jazzy --colcon-test-args "--cmake-args -DCMAKE_BUILD_TYPE=Release" --debug
+colcon --log-level=info test-in-container --ros-distro lyrical --colcon-test-args "--cmake-args -DCMAKE_BUILD_TYPE=Release" --debug
 ```
 
 Usage help:
@@ -232,7 +232,7 @@ colcon release-in-container
 
 Advanced usage:
 ```
-colcon --log-level=info release-in-container --ros-distro jazzy --bloom-generator rosdebian --debug
+colcon --log-level=info release-in-container --ros-distro lyrical --bloom-generator rosdebian --debug
 ```
 
 Usage help:
@@ -309,7 +309,7 @@ If you're developing on an x86_64 laptop but need to build ARM packages for devi
 
 ```bash
 # Build for ARM at native speed using a remote ARM server
-colcon build-in-container --remote https://arm-server-ip:8443 --ros-distro jazzy
+colcon build-in-container --remote https://arm-server-ip:8443 --ros-distro lyrical
 ```
 
 This avoids the slow performance of QEMU emulation by building directly on ARM hardware.

--- a/colcon_in_container/providers/_helper.py
+++ b/colcon_in_container/providers/_helper.py
@@ -16,7 +16,7 @@
 from platform import processor
 
 
-_ros2_ubuntu_distro = {'rolling': 'noble',
+_ros2_ubuntu_distro = {'rolling': 'resolute',
                        'foxy': 'focal',
                        'humble': 'jammy',
                        'jazzy': 'noble',

--- a/colcon_in_container/providers/_helper.py
+++ b/colcon_in_container/providers/_helper.py
@@ -20,7 +20,8 @@ _ros2_ubuntu_distro = {'rolling': 'resolute',
                        'foxy': 'focal',
                        'humble': 'jammy',
                        'jazzy': 'noble',
-                       'kilted': 'noble'}
+                       'kilted': 'noble',
+                       'lyrical': 'resolute'}
 
 
 def get_ubuntu_distro(ros_distro):

--- a/colcon_in_container/providers/config/cloud-init.yaml
+++ b/colcon_in_container/providers/config/cloud-init.yaml
@@ -1,6 +1,10 @@
 ## template: jinja
 #cloud-config
 
+bootcmd:
+ - [apt-get, update]
+ - [apt-get, install, -y, gpg]
+
 {% if not pro_token %}
 apt:
   sources:

--- a/colcon_in_container/verb/_parser.py
+++ b/colcon_in_container/verb/_parser.py
@@ -18,7 +18,7 @@ from os import getenv
 from colcon_in_container.logging import logger
 
 
-_ros_distro_choices = ['rolling', 'humble', 'jazzy', 'kilted']
+_ros_distro_choices = ['rolling', 'humble', 'jazzy', 'kilted', 'lyrical']
 _eol_ros_distro_choices = ['foxy']
 
 


### PR DESCRIPTION
- Migrate Rolling to 26.04.
- Add Lyrical on 26.04

Adding gpg as a boot-cmd was necessary since `ubuntu-minimal:26.04` doesn't include gpg so we can't add the ROS 2 with cloud init by defaut.